### PR TITLE
feat: Add Termux setup script and execution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Project Documentation
+
+This repository contains scripts and documentation for setting up various environments.
+
+## Available Scripts and Guides
+
+### 1. Termux Setup for Android (`setup_termux.sh`)
+
+The `setup_termux.sh` script is designed to automate the setup of a Termux environment on an Android device. It performs the following actions:
+- Updates and upgrades all installed packages.
+- Installs essential tools: `vim`, `wget`, `git`, and `openssh`.
+- Sets up Termux storage access by running `termux-setup-storage`.
+- Starts an OpenSSH server (`sshd`) to allow remote connections to your device.
+- Displays the command needed to connect to your device via SSH from another computer.
+
+**How to use this script on Android:**
+For detailed instructions on downloading and running this script within Termux, please refer to the [**`run_script_android.md`**](./run_script_android.md) guide.
+
+### 2. Running `setup_termux.sh` on Android (`run_script_android.md`)
+
+The [**`run_script_android.md`**](./run_script_android.md) file provides a step-by-step guide on how to:
+- Install Termux on your Android device.
+- Download the `setup_termux.sh` script.
+- Make the script executable.
+- Run the script to set up your environment.
+- It also includes convenient one-liner commands to download and execute the script directly, for users who understand the security implications.
+
+### 3. Ubuntu Installation Guide (`new_ubuntu_instalation.md`)
+
+The [**`new_ubuntu_instalation.md`**](./new_ubuntu_instalation.md) file contains instructions and guidance for setting up a standard Ubuntu desktop or server environment. This is distinct from the Termux setup, which is specific to Android.
+
+If you are looking to set up a fresh Ubuntu system, please consult this document.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit pull requests or open issues to improve these scripts and documentation.

--- a/run_script_android.md
+++ b/run_script_android.md
@@ -1,0 +1,68 @@
+# How to Run `setup_termux.sh` on Android using Termux
+
+This guide explains how to download and execute the `setup_termux.sh` script on your Android device using the Termux application. This script helps in setting up your Termux environment with essential packages like `vim`, `wget`, `git`, and `openssh`, and also starts an SSH server.
+
+## Prerequisites
+
+1.  **Install Termux**: If you haven't already, download and install Termux from F-Droid or the Google Play Store.
+    *   [Termux on F-Droid](https://f-droid.org/en/packages/com.termux/)
+    *   Note: The Play Store version might be outdated. F-Droid is generally recommended for the latest updates.
+
+## Steps to Run the Script
+
+1.  **Open Termux**: Launch the Termux app on your Android device.
+
+2.  **Download the script**:
+    You can download the `setup_termux.sh` script using `curl` or `wget`. The script is hosted at `https://github.com/samirma/cookbook/blob/main/setup_termux.sh`. The raw content URL is `https://raw.githubusercontent.com/samirma/cookbook/main/setup_termux.sh`.
+
+    Using `curl`:
+    ```bash
+    curl -fsSL -o setup_termux.sh https://raw.githubusercontent.com/samirma/cookbook/main/setup_termux.sh
+    ```
+
+    Or using `wget`:
+    ```bash
+    wget -O setup_termux.sh https://raw.githubusercontent.com/samirma/cookbook/main/setup_termux.sh
+    ```
+
+3.  **Make the script executable**:
+    After downloading, you need to give the script execution permissions.
+    ```bash
+    chmod +x setup_termux.sh
+    ```
+
+4.  **Run the script**:
+    Now you can execute the script.
+    ```bash
+    ./setup_termux.sh
+    ```
+    The script will then:
+    *   Update and upgrade your Termux packages.
+    *   Install `vim`, `wget`, `git`, and `openssh`.
+    *   Run `termux-setup-storage` (you'll need to grant storage permission when prompted).
+    *   Start the `sshd` server.
+    *   Display the command to connect to your device via SSH.
+
+## One-liner Command to Download and Run
+
+For convenience, you can download and execute the script in a single command. This is similar to how some other installation scripts (like Docker's) are run.
+
+**Make sure you trust the source of the script before running it this way.**
+
+The raw content URL for the script is `https://raw.githubusercontent.com/samirma/cookbook/main/setup_termux.sh`.
+
+Using `curl`:
+```bash
+curl -fsSL https://raw.githubusercontent.com/samirma/cookbook/main/setup_termux.sh | bash
+```
+
+Or using `wget`:
+```bash
+wget -qO - https://raw.githubusercontent.com/samirma/cookbook/main/setup_termux.sh | bash
+```
+
+This command fetches the script content and pipes it directly to `bash` for execution.
+
+---
+
+The URLs provided point to the `setup_termux.sh` script in the `main` branch of the `samirma/cookbook` GitHub repository.

--- a/setup_termux.sh
+++ b/setup_termux.sh
@@ -1,0 +1,24 @@
+#!/data/data/com.termux/files/usr/bin/bash
+
+# Update and upgrade packages
+echo "Updating and upgrading packages..."
+pkg update -y && pkg upgrade -y
+
+# Install vim, wget, git, and openssh
+echo "Installing vim, wget, git, and openssh..."
+pkg install vim wget git openssh -y
+
+# Setup termux storage
+echo "Setting up Termux storage..."
+termux-setup-storage
+
+# Start the SSH server
+echo "Starting SSH server..."
+sshd
+
+# Display SSH connection command
+echo "SSH server started."
+echo "To connect from another computer, use the following command:"
+echo "ssh -p 8022 $(whoami)@$(ifconfig wlan0 | awk '/inet / {print $2}')"
+echo "You might need to replace wlan0 with the correct network interface if Wi-Fi is not used."
+echo "Use 'ip addr' or 'ifconfig' to find your device's IP address if the above command doesn't work."


### PR DESCRIPTION
Adds a new bash script `setup_termux.sh` to automate the setup of a Termux environment on Android. This includes:
- Updating packages
- Installing vim, wget, git, openssh
- Setting up termux-storage
- Starting sshd and displaying connection info

Also adds `run_script_android.md` to explain how you can download and run the script in Termux, including one-liner options. The URLs in `run_script_android.md` now point to the `samirma/cookbook` GitHub repository.

Creates a `README.md` to document these new files and reference the existing `new_ubuntu_instalation.md`.