### PR TITLE
Add public-instance fallback tier to searxng-server skill

### DIFF
--- a/ai_agents/README.md
+++ b/ai_agents/README.md
@@ -27,7 +27,7 @@ curl -fsSL https://raw.githubusercontent.com/samirma/cookbook/main/ai_agents/ski
 
 ### searxng-server
 
-The agent's default web search tool. Query the internet using a self-hosted SearXNG metasearch engine discovered on the local network via mDNS. Features cache-aware IP discovery with health validation, and falls back to SearchWeb if the server is unreachable.
+The agent's default web search tool. Query the internet using a self-hosted SearXNG metasearch engine discovered on the local network via mDNS. Features cache-aware IP discovery with health validation, and a two-stage fallback when the local server is unreachable: a validated public SearXNG instance first, then the built-in WebSearch tool.
 
 ```bash
 BASE_URL="https://raw.githubusercontent.com/samirma/cookbook/main/ai_agents/skills/searxng-server"
@@ -36,6 +36,7 @@ DEST_DIR="$HOME/.agents/skills/searxng-server"
 
 curl -fsSL "${BASE_URL}/SKILL.md" --create-dirs -o "${DEST_DIR}/SKILL.md"
 curl -fsSL "${BASE_URL}/references/discovery.md" --create-dirs -o "${DEST_DIR}/references/discovery.md"
+curl -fsSL "${BASE_URL}/references/public-fallback.md" --create-dirs -o "${DEST_DIR}/references/public-fallback.md"
 curl -fsSL "${BASE_URL}/references/setup.md" --create-dirs -o "${DEST_DIR}/references/setup.md"
 curl -fsSL "${BASE_URL}/references/queries.md" --create-dirs -o "${DEST_DIR}/references/queries.md"
 curl -fsSL "${BASE_URL}/references/troubleshooting.md" --create-dirs -o "${DEST_DIR}/references/troubleshooting.md"

--- a/ai_agents/skills/searxng-server/SKILL.md
+++ b/ai_agents/skills/searxng-server/SKILL.md
@@ -5,7 +5,9 @@ description: >
   SearXNG metasearch engine discovered on the local network via mDNS.
   Use when the user asks to search, look up, find, research, or fact-check anything;
   when current or external information is needed; or for any task requiring web search.
-  If the SearXNG server is unreachable after discovery attempts, fall back to the SearchWeb tool.
+  If the local server is unreachable after discovery attempts, fall back to a validated
+  public SearXNG instance (references/public-fallback.md); if no public instance passes
+  validation, fall back to the built-in WebSearch tool.
 ---
 
 # SearXNG Web Search
@@ -21,6 +23,16 @@ The SearXNG server IP is cached so it does not need to be rediscovered on every 
 3. **Discover** — if cached IP is missing or stale, discover via mDNS or network scan
 4. **Save** — write the validated IP back to the cache file
 
+## Fallback Chain
+
+Work down this chain and stop at the first tier that yields results. Do not
+retry a failed tier within the same task:
+
+1. **Local server** — cache → validate → discover (the workflow above)
+2. **Public SearXNG instance** — pinned, cached, or candidate instance, always
+   validated before use — see [references/public-fallback.md](references/public-fallback.md)
+3. **WebSearch** — the built-in web search tool, when no SearXNG instance is usable
+
 ## Quick Reference
 
 | Task | Command |
@@ -35,12 +47,14 @@ The SearXNG server IP is cached so it does not need to be rediscovered on every 
 |----------|-------------|---------|
 | `SEARXNG_IP` | Server IP address (overrides cache) | (from cache or discovery) |
 | `SEARXNG_PORT` | Server port override | `8080` |
+| `SEARXNG_PUBLIC_URL` | Pinned public/remote instance tried first in the public fallback tier (full URL) | (none) |
 
 ## Reference Files
 
 Load these only when needed:
 
 - **[references/discovery.md](references/discovery.md)** — Cache-aware IP discovery: mDNS browsing, network scan, validation
+- **[references/public-fallback.md](references/public-fallback.md)** — Public-instance backup tier: candidates, validation, caching, pinning
 - **[references/setup.md](references/setup.md)** — Prerequisites, cache setup, server-side JSON requirement
 - **[references/queries.md](references/queries.md)** — Search filters, jq extraction patterns, API response format
 - **[references/troubleshooting.md](references/troubleshooting.md)** — Common issues and fixes

--- a/ai_agents/skills/searxng-server/references/public-fallback.md
+++ b/ai_agents/skills/searxng-server/references/public-fallback.md
@@ -1,0 +1,108 @@
+# Public Instance Fallback
+
+When the local SearXNG server cannot be found or used, try a public SearXNG
+instance before giving up on SearXNG entirely. The full fallback chain is:
+
+1. **Local server** — cache → validate → discover (see [discovery.md](discovery.md))
+2. **Public SearXNG instance** — this file
+3. **Built-in web search tool** (WebSearch) — when no SearXNG instance is usable
+
+## Why validation is mandatory
+
+Public instances rarely enable the JSON API. `format=json` only works when the
+operator adds `json` to `search.formats` in `settings.yml`; otherwise the
+instance returns **403 Forbidden by design**. Most public operators leave JSON
+disabled deliberately to deter bot scraping, and the SearXNG project publishes
+no list of JSON-enabled public instances. Instance behavior also changes
+without notice. So never assume a public instance works — validate before
+every use (cheap, one request) and expect to fall through to WebSearch when
+none pass.
+
+## Selection order
+
+1. **Pinned instance** — if `SEARXNG_PUBLIC_URL` is set, validate and use it
+2. **Cached instance** — read `~/.cache/searxng-server/public_url`, validate it
+3. **Candidate list** — probe the candidates below in order; first valid wins; save it to the cache
+4. **None valid** — fall back to the built-in web search tool (WebSearch)
+
+## Validation
+
+The same authoritative check used for the local server — a JSON search that
+parses. Note `-f`: without it, a 403/404 body would count as success.
+
+```bash
+check_public() {
+    curl -sfG --connect-timeout 3 --max-time 10 \
+        --data-urlencode "q=test" --data "format=json" \
+        "${1}/search" | jq -e '.results' >/dev/null 2>&1
+}
+```
+
+- **403** — the operator disabled JSON output; skip the instance, do not retry
+- **429 or a CAPTCHA page** — rate limited; skip it for the rest of the session
+
+## Candidate public instances
+
+Reputable, long-running instances taken from https://searx.space. Most will
+still fail the JSON check — that is expected; the loop exists to catch the
+ones that do not:
+
+```bash
+PUBLIC_CANDIDATES=(
+    "https://searx.be"
+    "https://searx.tiekoetter.com"
+    "https://priv.au"
+    "https://opnxng.com"
+    "https://search.inetol.net"
+)
+```
+
+Refresh this list occasionally from https://searx.space (filter by uptime and
+grade; uptime history at https://uptime.searxng.org) — public instances come
+and go.
+
+## Full fallback sequence
+
+```bash
+PUBLIC_CACHE="$HOME/.cache/searxng-server/public_url"
+SEARXNG_URL=""
+
+for candidate in "${SEARXNG_PUBLIC_URL}" "$(cat "$PUBLIC_CACHE" 2>/dev/null)" "${PUBLIC_CANDIDATES[@]}"; do
+    [ -z "$candidate" ] && continue
+    if check_public "$candidate"; then
+        SEARXNG_URL="$candidate"
+        mkdir -p "$(dirname "$PUBLIC_CACHE")"
+        echo "$candidate" > "$PUBLIC_CACHE"
+        break
+    fi
+done
+
+if [ -n "$SEARXNG_URL" ]; then
+    curl -sfG --connect-timeout 5 --max-time 15 \
+        --data-urlencode "q=YOUR QUERY" --data "format=json" \
+        "${SEARXNG_URL}/search" | jq '.results'
+else
+    echo "No public SearXNG instance usable — fall back to the WebSearch tool"
+fi
+```
+
+The result format and jq extraction patterns from
+[queries.md](queries.md) apply unchanged — only the base URL differs.
+
+## Etiquette on public instances
+
+Public instances are donated capacity. Use them as a backup, not a default:
+prefer the local server, keep query volume low, never loop retries against
+403/429 responses, and drop an instance for the session at the first sign of
+rate limiting.
+
+## The reliable backup: a remote instance you control
+
+Because public instances rarely allow JSON and can revoke it at any time, the
+dependable off-network backup is a second instance you operate (e.g. on a VPS)
+with `json` enabled in `search.formats` (see [setup.md](setup.md)). Pin it so
+it is always tried first:
+
+```bash
+export SEARXNG_PUBLIC_URL="https://searxng.example.com"
+```

--- a/ai_agents/skills/searxng-server/references/setup.md
+++ b/ai_agents/skills/searxng-server/references/setup.md
@@ -35,6 +35,7 @@ mkdir -p ~/.cache/searxng-server
 |----------|-------------|---------|
 | `SEARXNG_IP` | Server IP address (overrides cache) | (from cache or discovery) |
 | `SEARXNG_PORT` | Server port override | `8080` |
+| `SEARXNG_PUBLIC_URL` | Pinned public/remote instance tried first in the public fallback tier (full URL) | (none) |
 
 ## Server-Side Requirement
 

--- a/ai_agents/skills/searxng-server/references/troubleshooting.md
+++ b/ai_agents/skills/searxng-server/references/troubleshooting.md
@@ -32,6 +32,10 @@ dns-sd -Z _http._tcp local | grep -A 3 -i searxng
    nmap -p 8080 --open 192.168.1.0/24
    curl -s --connect-timeout 5 "http://<IP>:8080/healthz"
    ```
+6. **Local server truly unreachable** — stop diagnosing mid-task and continue
+   the search via the fallback chain: a validated public instance
+   (see [public-fallback.md](public-fallback.md)), then the built-in
+   WebSearch tool
 
 ## Connection Issues
 


### PR DESCRIPTION
When the local SearXNG server cannot be found or used, the skill now tries a public SearXNG instance before resorting to the built-in web search tool, making the fallback chain: local -> public -> WebSearch.

- New references/public-fallback.md: selection order (pinned env var, cached URL, candidate list), mandatory JSON-API validation (public instances return 403 for format=json unless the operator enables it), result caching in ~/.cache/searxng-server/public_url, rate-limit etiquette, and a recommendation to pin a self-controlled remote instance via SEARXNG_PUBLIC_URL.
- SKILL.md: document the fallback chain, add SEARXNG_PUBLIC_URL to the env table, link the new reference, and name the built-in fallback tool correctly (WebSearch, previously "SearchWeb").
- troubleshooting.md: point "Server Not Found" at the fallback chain instead of ending at manual diagnostics.
- setup.md: add SEARXNG_PUBLIC_URL to the env table.
- ai_agents/README.md: update skill description and install script to include the new reference file.


Claude-Session: https://claude.ai/code/session_01JX8hQxFqKAfqtALN1orL9d